### PR TITLE
Tweak for test cases

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source "http://rubygems.org"
 
-gem "sqlite3", ">=1.3.7"
+gemspec

--- a/fluent-plugin-sqlite3.gemspec
+++ b/fluent-plugin-sqlite3.gemspec
@@ -10,5 +10,8 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://github.com/tmtk75/fluent-plugin-sqlite3.git'
 
   s.add_dependency "fluentd"
-  s.add_dependency "sqlite3"
+  s.add_dependency "sqlite3", ">= 1.3.7"
+  s.add_development_dependency "test-unit", "~> 3.2.0"
+  s.add_development_dependency "rake", "~> 12.0.0"
+  s.add_development_dependency "bundler", "~> 1.13.0"
 end

--- a/test/fluent/plugin/test_out_sqlite3.rb
+++ b/test/fluent/plugin/test_out_sqlite3.rb
@@ -1,31 +1,55 @@
 require 'fluent/test'
 require 'fluent/plugin/out_sqlite3'
+require 'fileutils'
 
 $log = Object.new.instance_eval {|obj| def method_missing(method, *args); end; self }
 
 class Fluent::Sqlite3OutputTest < Test::Unit::TestCase
   def setup
     Fluent::Test.setup
+    @db = ::SQLite3::Database.new DBPATH
   end
-  
+
+  def teardown
+    @db.close
+    FileUtils.rm(DBPATH)
+  end
+
+  DBPATH = "a.db"
   CONFIG = %[
-    path a.db
+    path #{DBPATH}
   ]
 
-  def create_driver(conf=CONFIG, tag='test')
+  TAG = 'test.records'
+
+  def create_driver(conf=CONFIG, tag=TAG)
     Fluent::Test::BufferedOutputTestDriver.new(Fluent::Sqlite3Output, tag) {
       def start
       end
     }.configure(conf)
   end
 
+  def get_documents(driver, table = TAG.split('.')[1])
+    rows = []
+    @db.execute( "select * from #{table}" ) do |row|
+      rows << row
+    end
+    rows
+  end
+
   def test_format
+    d = create_driver
+    time = Time.now.to_i
+    d.emit({'record' => 'message', 'value' => 0.12}, time)
+    d.expect_format [TAG, time, {'record' => 'message', 'value' => 0.12}].to_msgpack
+    d.run
   end
 
   def test_write
     d = create_driver
-    collection_name, documents = d.run
-    assert_equal [{}, {}], documents
-    assert_equal 'test', collection_name
+    d.emit({'record' => 'message', 'value' => 0.12})
+    d.run
+    doc = get_documents(d)
+    assert_equal [[1, 'message', 0.12]], doc
   end
 end


### PR DESCRIPTION
I've tried to add basic test cases for `#format` and `#write`.
And I tidied up gemspec and Gemfile to start CI the following commands:

```bash
$ bundle install
$ bundle exec rake test
```

If any questions for implementations or test cases, please don't hesitate to let me know. :wink:

BTW, do you interested in v0.14 new APIs?
If you interested in it, please let me know, too. :thinking: