### PR TITLE
Migrate v1 API

### DIFF
--- a/fluent-plugin-sqlite3.gemspec
+++ b/fluent-plugin-sqlite3.gemspec
@@ -13,5 +13,5 @@ Gem::Specification.new do |s|
   s.add_dependency "sqlite3", ">= 1.3.7"
   s.add_development_dependency "test-unit", "~> 3.2.0"
   s.add_development_dependency "rake", "~> 12.0.0"
-  s.add_development_dependency "bundler", "~> 1.13.0"
+  s.add_development_dependency "bundler", "~> 1.13"
 end

--- a/fluent-plugin-sqlite3.gemspec
+++ b/fluent-plugin-sqlite3.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.files       = ["lib/fluent/plugin/out_sqlite3.rb"]
   s.homepage    = 'https://github.com/tmtk75/fluent-plugin-sqlite3.git'
 
-  s.add_dependency "fluentd"
+  s.add_dependency "fluentd", [">= 0.14.15", "< 2"]
   s.add_dependency "sqlite3", ">= 1.3.7"
   s.add_development_dependency "test-unit", "~> 3.2.0"
   s.add_development_dependency "rake", "~> 12.0.0"

--- a/lib/fluent/plugin/out_sqlite3.rb
+++ b/lib/fluent/plugin/out_sqlite3.rb
@@ -1,13 +1,20 @@
 require "sqlite3"
+require "fluent/plugin/output"
 
-class Fluent::Sqlite3Output < Fluent::BufferedOutput
+class Fluent::Plugin::Sqlite3Output < Fluent::Plugin::Output
   Fluent::Plugin.register_output('sqlite3', self)
+
+  DEFAULT_BUFFER_TYPE = "memory"
 
   config_param :path,     :string
   config_param :table,    :string, :default => nil
   config_param :columns,  :string, :default => nil
   config_param :includes, :string, :default => nil
   config_param :excludes, :string, :default => nil
+
+  config_section :buffer do
+    config_set_default :@type, DEFAULT_BUFFER_TYPE
+  end
 
   def initialize
     super
@@ -22,7 +29,7 @@ class Fluent::Sqlite3Output < Fluent::BufferedOutput
   end
 
   DELIMITER = / *, */
-  
+
   def start
     super
     @db = ::SQLite3::Database.new @path
@@ -39,10 +46,10 @@ class Fluent::Sqlite3Output < Fluent::BufferedOutput
   end
 
   def shutdown
-    super
-    $log.debug "shutdown"
+    log.debug "shutdown"
     @stmts.each {|k,v| v.close}
     @db.close
+    super
   end
 
   def format(tag, time, record)
@@ -56,15 +63,19 @@ class Fluent::Sqlite3Output < Fluent::BufferedOutput
       @db.commit
     rescue => ex
       @db.rollback
-      $log.error "rollback: ", ex
+      log.error "rollback: ", ex
       raise
     end
+  end
+
+  def formatted_to_msgpack_binary?
+    true
   end
 
   def write1(chunk)
     chunk.msgpack_each do |tag, time, record|
       if record.keys.length == 0
-        $log.warn "no any keys for #{tag}"
+        log.warn "no any keys for #{tag}"
         return
       end
       table = (@table or tag.split('.')[1]) # param 'table' or 2nd later part of tag.
@@ -78,7 +89,7 @@ class Fluent::Sqlite3Output < Fluent::BufferedOutput
         cols = record.keys.join ","
         @db.execute "CREATE TABLE IF NOT EXISTS #{table} (id INTEGER PRIMARY KEY AUTOINCREMENT,#{cols})"
         @stmts[table] = @db.prepare (a = to_insert(table, cols))
-        $log.debug "create a new table, #{table.upcase} (it may have been already created)"
+        log.debug "create a new table, #{table.upcase} (it may have been already created)"
       end
       @stmts[table].execute record
     end


### PR DESCRIPTION
Hi, @tmtk75 !
I've tried to use brand new v1 API for Output Plugin.
Could you take a look?

If these changes are acceptable for you, please release new version as v1.0.0 instead of v0.2.0.
This PR breaks backward compatibility because brand new v1 API does not have backward compatibility.